### PR TITLE
feat: button 컴포넌트 disabled props로 분리

### DIFF
--- a/src/components/Buttons/Button.jsx
+++ b/src/components/Buttons/Button.jsx
@@ -2,26 +2,34 @@ import React from "react";
 import PropTypes from "prop-types";
 
 export default function Button(props) {
-  const { variant, text, type, size = "small", focus = false, onClick } = props;
+  const {
+    variant,
+    text,
+    type,
+    size = "small",
+    disabled = false,
+    focus = false,
+    onClick,
+  } = props;
 
-  let buttonType = variant;
+  let buttonType;
   if (variant === "contained") {
-    buttonType = "bg-sky-700 text-gray-100";
-  } else if (variant === "outlined") {
-    buttonType =
-      "text-indigo-900 border-2 border-indigo-900 hover:bg-indigo-100";
-  } else if (variant === "disabled") {
-    buttonType = "bg-gray-600 text-gray-300 cursor-default";
+    buttonType = disabled
+      ? "bg-gray-600 text-gray-300 cursor-not-allowed"
+      : "bg-sky-700 text-gray-100";
+  } else {
+    buttonType = disabled
+      ? "border-2 border-gray-300 text-gray-300 cursor-not-allowed"
+      : "text-indigo-900 border-2 border-indigo-900 hover:bg-indigo-100";
   }
 
   let buttonSize = size;
   buttonSize = buttonSize === "large" ? "text-2xl" : "text-base";
 
   let buttonFocus = focus;
-  buttonFocus =
-    buttonFocus === true
-      ? "focus:outline-none focus:ring-1 focus:ring-offset-2"
-      : "";
+  buttonFocus = buttonFocus
+    ? "focus:outline-none focus:ring-1 focus:ring-offset-2"
+    : "";
 
   return (
     <button
@@ -35,10 +43,11 @@ export default function Button(props) {
 }
 
 Button.propTypes = {
-  variant: PropTypes.oneOf(["contained", "outlined", "disabled"]).isRequired,
+  variant: PropTypes.oneOf(["contained", "outlined"]).isRequired,
   text: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   size: PropTypes.oneOf(["small", "large"]),
+  disabled: PropTypes.bool,
   focus: PropTypes.bool,
   onClick: PropTypes.func,
 };

--- a/src/stories/Button.stories.jsx
+++ b/src/stories/Button.stories.jsx
@@ -7,11 +7,12 @@ export default {
   argTypes: {
     variant: {
       control: { type: "radio" },
-      options: ["contained", "outlined", "disabled"],
+      options: ["contained", "outlined"],
     },
     text: { control: "text" },
     type: { control: { type: "radio" }, options: ["submit", "button"] },
     size: { control: { type: "radio" }, options: ["small", "large"] },
+    disabled: { control: { type: "boolean" } },
     focus: { control: { type: "boolean" } },
     onClick: { action: "clicked" },
   },
@@ -26,6 +27,7 @@ Contained.args = {
   text: "contained",
   type: "button",
   size: "small",
+  disabled: false,
   focus: true,
 };
 
@@ -36,15 +38,17 @@ Outlined.args = {
   text: "outlined",
   type: "button",
   size: "large",
+  disabled: false,
   focus: true,
 };
 
 export const Disabled = Template.bind({});
 
 Disabled.args = {
-  variant: "disabled",
+  variant: "contained",
   text: "disabled",
   type: "button",
   size: "small",
+  disabled: true,
   focus: true,
 };


### PR DESCRIPTION
variant의 종류 (contained, outlined, disabled)중에 disabled를 아예 props로 빼서 
contained와 outlined에 각각 disabled이 설정 가능하도록 구현했습니다. 스토리북 보시면 더 이해하기 쉬우실거에요!