### PR TITLE
Refactor routing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,17 +1,13 @@
 import React from "react";
-import { Routes, Route } from "react-router-dom";
-import MainPage from "@page/main";
-import MovieList from "@page/movieList/MovieList";
-import Search from "@page/search/Search";
+import CustomRoutes from "./routes";
 
 function App() {
   return (
-    <Routes>
-      <Route path="/" element={<MainPage />} />
-      <Route path="/movielist" element={<MovieList />} />
-      <Route path="/contact" element={<h1>Contact</h1>} />
-      <Route path="/search" element={<Search />} />
-    </Routes>
+    <>
+      <div className="fixed backgroundImg"></div>
+      <div className="backgroundCover"></div>
+      <CustomRoutes />
+    </>
   );
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -4,8 +4,6 @@ import CustomRoutes from "./routes";
 function App() {
   return (
     <>
-      <div className="fixed backgroundImg"></div>
-      <div className="backgroundCover"></div>
       <CustomRoutes />
     </>
   );

--- a/src/Layouts/AuthLayout.jsx
+++ b/src/Layouts/AuthLayout.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { Outlet } from "react-router-dom";
+import Container from "./Container";
+
+export default function AuthLayout() {
+  return (
+    <Container>
+      <Outlet />
+    </Container>
+  );
+}

--- a/src/Layouts/AuthLayout.jsx
+++ b/src/Layouts/AuthLayout.jsx
@@ -1,11 +1,15 @@
 import React from "react";
 import { Outlet } from "react-router-dom";
 import Container from "./Container";
+import DefaultBackgroundImg from "./DefaultBackgroundImg";
 
 export default function AuthLayout() {
   return (
-    <Container>
-      <Outlet />
-    </Container>
+    <>
+      <DefaultBackgroundImg />
+      <Container>
+        <Outlet />
+      </Container>
+    </>
   );
 }

--- a/src/Layouts/Container.jsx
+++ b/src/Layouts/Container.jsx
@@ -1,0 +1,30 @@
+import { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import Appbar from "../pages/common/appbar/Appbar";
+
+export default function Container({ children }) {
+  const [scrollPosition, setScrollPosition] = useState(0);
+  const updateScroll = () => {
+    setScrollPosition(window.scrollY || document.documentElement.scrollTop);
+  };
+  useEffect(() => {
+    window.addEventListener("scroll", updateScroll);
+  });
+  return (
+    <div
+      className={`container  pb-[100px] relative ml-auto mr-auto md:pt-28 bg-transparent ${
+        scrollPosition > 200 ? "pt-28" : ""
+      }`}
+    >
+      <Appbar scrollPosition={scrollPosition} />
+      {children}
+      <footer className="absolute bottom-0 w-full bg-black text-textHighlightColor h-36">
+        footer 영역
+      </footer>
+    </div>
+  );
+}
+
+Container.propTypes = {
+  children: PropTypes.element,
+};

--- a/src/Layouts/Container.jsx
+++ b/src/Layouts/Container.jsx
@@ -12,7 +12,7 @@ export default function Container({ children }) {
   });
   return (
     <div
-      className={`container  pb-[100px] relative ml-auto mr-auto md:pt-28 bg-transparent ${
+      className={`container pb-[100px] relative ml-auto mr-auto md:pt-28 bg-transparent ${
         scrollPosition > 200 ? "pt-28" : ""
       }`}
     >

--- a/src/Layouts/DefaultBackgroundImg.jsx
+++ b/src/Layouts/DefaultBackgroundImg.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function DefaultBackgroundImg() {
+  return (
+    <div className="fixed backgroundImg">
+      <div className="backgroundCover"></div>
+    </div>
+  );
+}

--- a/src/Layouts/PublicLayout.jsx
+++ b/src/Layouts/PublicLayout.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { Outlet } from "react-router-dom";
+import Container from "./Container";
+
+export default function PublicLayout() {
+  return (
+    <Container>
+      <Outlet />
+    </Container>
+  );
+}

--- a/src/Layouts/PublicLayout.jsx
+++ b/src/Layouts/PublicLayout.jsx
@@ -1,11 +1,15 @@
 import React from "react";
 import { Outlet } from "react-router-dom";
 import Container from "./Container";
+import DefaultBackgroundImg from "./DefaultBackgroundImg";
 
 export default function PublicLayout() {
   return (
-    <Container>
-      <Outlet />
-    </Container>
+    <>
+      <DefaultBackgroundImg />
+      <Container>
+        <Outlet />
+      </Container>
+    </>
   );
 }

--- a/src/pages/common/appbar/Appbar.jsx
+++ b/src/pages/common/appbar/Appbar.jsx
@@ -1,16 +1,26 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React from "react";
+import React, { useState } from "react";
 import SearchBar from "@page/common/appbar/SearchBar";
 import { BsFillPersonFill as ProfileIcon } from "react-icons/bs";
 import { HiMenu as MenuIcon } from "react-icons/hi";
 import Button from "@component/Button";
+import JoinModal from "../modal/JoinModal";
+import LoginModal from "../modal/LoginModal";
 
 export default function Appbar(props) {
-  const { onOpenModal, scrollPosition } = props;
+  const { scrollPosition } = props;
+  const [showJoinModal, setShowJoinModal] = useState(false);
+  const [showLoginModal, setShowLoginModal] = useState(false);
+
+  const handleJoinModalOpen = () => {
+    setShowJoinModal((prevState) => !prevState);
+  };
+
+  const handleLoginModalOpen = () => {
+    setShowLoginModal((prevState) => !prevState);
+  };
 
   return (
-    // 전체 container
-
     <header
       className={`z-10 flex items-center justify-center w-full pt-5 pb-5 text-white
         bg-transparent h-28 md:fixed md:top-0 md:bg-headerBackgroundColor ${
@@ -36,15 +46,18 @@ export default function Appbar(props) {
         </div>
         <SearchBar />
         <div className="flex items-center mt-2 ml-auto font-bold tracking-widest text-l text-textMainColor nav_container md:hidden">
-          <a className="ml-4 mr-4 cursor-pointer tablet:ml-2 tablet:mr-2 hover:text-textHighlightColor">
+          <span className="ml-4 mr-4 cursor-pointer tablet:ml-2 tablet:mr-2 hover:text-textHighlightColor">
             PLAYLISTS
-          </a>
-          <a className="ml-4 mr-4 cursor-pointer tablet:ml-2 tablet:mr-2 hover:text-textHighlightColor ">
+          </span>
+          <span className="ml-4 mr-4 cursor-pointer tablet:ml-2 tablet:mr-2 hover:text-textHighlightColor ">
             MOVIES
-          </a>
-          <a className="ml-4 mr-4 cursor-pointer tablet:ml-2 tablet:mr-2 hover:text-textHighlightColor">
+          </span>
+          <span
+            className="ml-4 mr-4 cursor-pointer tablet:ml-2 tablet:mr-2 hover:text-textHighlightColor"
+            onClick={handleLoginModalOpen}
+          >
             LOG IN
-          </a>
+          </span>
           <Button
             text="JOIN"
             size="small"
@@ -52,9 +65,7 @@ export default function Appbar(props) {
             color="text-white"
             backgroundColor="bg-themePink"
             borderRadius="rounded-2xl"
-            onClick={() => {
-              onOpenModal(true);
-            }}
+            onClick={handleJoinModalOpen}
           ></Button>
 
           {/* <BsFillPersonFill className="w-8 h-8" /> */}
@@ -63,6 +74,8 @@ export default function Appbar(props) {
           <MenuIcon className="hidden w-[40px] h-[40px] p-[3px] border-2 mr-0 mt-2 md:block " />
         </div>
       </div>
+      <LoginModal open={showLoginModal} onClose={setShowLoginModal} />
+      <JoinModal open={showJoinModal} onClose={setShowJoinModal} />
     </header>
   );
 }

--- a/src/pages/main/MainPage.jsx
+++ b/src/pages/main/MainPage.jsx
@@ -1,32 +1,16 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import Tag from "@component/Tag";
 import PlayListCard from "@page/common/playListCard";
 import EventBar from "@page/main/components/eventBar";
 import * as Mock from "@data/mock";
-import LoginModal from "@page/common/modal/LoginModal";
-import JoinModal from "@page/common/modal/JoinModal";
-import Appbar from "../common/appbar/Appbar";
 
 export default function MainPage() {
   // TODO movielist_container 공통 스타일로 빼기
-  const [showLoginModal, setShowLoginModal] = React.useState(false);
-  const [showJoinModal, setShowJoinModal] = React.useState(false);
-  const [scrollPosition, setScrollPosition] = useState(0);
-  const updateScroll = () => {
-    setScrollPosition(window.scrollY || document.documentElement.scrollTop);
-  };
-  useEffect(() => {
-    window.addEventListener("scroll", updateScroll);
-  });
+  const [showLoginModal, setShowLoginModal] = useState(false);
+  const [showJoinModal, setShowJoinModal] = useState(false);
+
   return (
-    <div
-      className={`container ml-auto mr-auto md:pt-28 ${
-        scrollPosition > 200 ? "pt-28" : ""
-      }`}
-    >
-      <div className="fixed backgroundImg"></div>
-      <div className="backgroundCover"></div>
-      <Appbar onOpenModal={setShowJoinModal} scrollPosition={scrollPosition} />
+    <>
       <div className="flex pl-6 text-2xl items-center w-[1250px] mr-auto ml-auto pt-6">
         <h1 className="pr-4 text-base">인기태그</h1>
         {Mock.popularTags.tags.map((tag, index) => {
@@ -110,11 +94,9 @@ export default function MainPage() {
         </div>
       </section>
       <div className="w-full h-20 mt-16"></div>
-      <footer className="w-full text-textHighlightColor h-36 ">
-        footer 영역
-      </footer>
+      {/* 
       <LoginModal open={showLoginModal} onClose={setShowLoginModal} />
-      <JoinModal open={showJoinModal} onClose={setShowJoinModal} />
-    </div>
+      <JoinModal open={showJoinModal} onClose={setShowJoinModal} /> */}
+    </>
   );
 }

--- a/src/pages/movieList/MovieList.jsx
+++ b/src/pages/movieList/MovieList.jsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from "react";
-import Appbar from "@page/common/appbar/Appbar";
+import React, { useEffect } from "react";
 import MovieCard from "./components/movieCard";
 import * as Constants from "@constant";
 import { useSelector, useDispatch } from "react-redux";
@@ -7,37 +6,19 @@ import * as action from "@data/rootActions";
 import * as selector from "@data/rootSelectors";
 
 export default function MovieList() {
-  const [showModal, setShowModal] = useState(false);
-  const [scrollPosition, setScrollPosition] = useState(0);
   const dispatch = useDispatch();
   const movieArray = useSelector(selector.movie.getPopularMovieList);
   async function getMovieList() {
-
     console.log("getMovieList");
     dispatch(action.movie.getPopularMovieList());
-
   }
   useEffect(() => {
     getMovieList();
   }, []);
 
-  const updateScroll = () => {
-    setScrollPosition(window.scrollY || document.documentElement.scrollTop);
-  };
-  useEffect(() => {
-    window.addEventListener("scroll", updateScroll);
-  });
   return (
-    <div
-      className={`container ml-auto mr-auto md:pt-28 ${
-        scrollPosition > 200 ? "pt-28" : ""
-      }`}
-    >
-      <div className="fixed backgroundImg"></div>
-      <div className="backgroundCover"></div>
-      <Appbar onOpenModal={setShowModal} scrollPosition={scrollPosition} />
-
-      <div className="flex justify-center ">
+    <>
+      <div className="flex justify-center h-[100vh] ">
         <div>
           <h1 className=" p-10 mb-8 font-[Dosis] font-bold text-white text-4xl">
             Popular Movies
@@ -60,6 +41,6 @@ export default function MovieList() {
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/pages/search/Search.jsx
+++ b/src/pages/search/Search.jsx
@@ -1,12 +1,10 @@
 import React, { useEffect, useState } from "react";
-import Appbar from "@page/common/appbar/Appbar";
 import * as MovieService from "@api/tmMovie/movie";
 import MovieSearchCard from "./components/movieSearchCard";
 import * as Constants from "@constant";
 import { useLocation } from "react-router-dom";
 
 export default function Search() {
-  const [showModal, setShowModal] = useState(false);
   const [movieList, setMovieList] = useState([]);
 
   const location = useLocation();
@@ -28,8 +26,7 @@ export default function Search() {
   }, [location.state.value]);
 
   return (
-    <div className="container ml-auto mr-auto pt-28 ">
-      <Appbar onOpenModal={setShowModal} />
+    <>
       <div className=" bg-[#020d18] ">
         <div className="flex justify-center ">
           <div>
@@ -58,6 +55,6 @@ export default function Search() {
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { useRoutes } from "react-router-dom";
+import AuthLayout from "../Layouts/AuthLayout";
+import PublicLayout from "../Layouts/PublicLayout";
+import MainPage from "../pages/main";
+import MovieList from "../pages/movieList/MovieList";
+import Search from "../pages/search/Search";
+
+export default function CustomRoutes() {
+  const publicRoutes = {
+    path: "/",
+    element: <PublicLayout />,
+    children: [
+      { path: "/", element: <MainPage /> },
+      { path: "/movielist", element: <MovieList /> },
+      { path: "/search", element: <Search /> },
+    ],
+  };
+
+  const authRoutes = {
+    path: "/",
+    element: <AuthLayout />,
+    children: [],
+  };
+  const routing = useRoutes([publicRoutes, authRoutes]);
+
+  return <>{routing}</>;
+}


### PR DESCRIPTION
어제 회의에서 제안해주신 내용 반영해서 코드 수정하였습니다.

# 페이지 라우팅 레이아웃 관련

- `Layout` 폴더에 `PublicLayout, AuthLayout, Container` 컴포넌트 추가(각 레이아웃은 Container 안에서 `Outlet`을 통해서 `children`을 렌더링)
-  `routes` 폴더에 `index` 파일 내에 `CustomRoutes` 라는 컴포넌트에 `publicRoutes, authRoutes` 두 객체를 전달 받는 `useRoutes `함수를 통해서 라우팅 구현
- `App` 파일 내에 기존에 `Routes-Route path / element` 구조로 선언되어 있던 라우팅 로직 CustomRoutes 로 대체

# 모달 로직 분리 관련

- 모달 열고 닫는 로직 AppBar 로 이동