### PR TITLE
feat(google login): 구글 로그인 백엔드 테스트 가능하도록 작업

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@craco/craco": "^6.4.3",
+    "@react-oauth/google": "^0.2.6",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",
     "@testing-library/user-event": "^13.5.0",

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -8,12 +8,14 @@ export const TM_MOVIE_IMAGE_URL = "https://image.tmdb.org/t/p/original";
 //TODO api key env로 바꿔야함
 export const TM_API_KEY = "4d48c467d91cd60bbd7ef0bffa7b1a73";
 
+// 카카오 로그인 구현 시 필요한 키값
 const KAKAO_CLIENT_ID = "7b3b8e4bac82885a106b3d0eac76cd86";
 const KAKAO_REDIRECT_URI = "http://localhost:3000/oauth/kakao";
 const KAKAO_CLIENT_SECRET = "6LX0v5unJyJuRvSwlnQejgoqE3FgzBFX";
 
 export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${KAKAO_REDIRECT_URI}&response_type=code`;
 
+// 네이버 로그인 구현 시 필요한 키값
 const NAVER_CLIENT_ID = "P9wXmSD_A0d2dUt21vm0";
 const NAVER_CLIENT_SECRET = "YIYyWZR319";
 const NAVER_REDIRECT_URI = "http://localhost:3000/oauth/naver";
@@ -21,3 +23,9 @@ const NAVER_REDIRECT_URI = "http://localhost:3000/oauth/naver";
 const STATE_STRING = encodeURI("accc", "UTF-8");
 
 export const NAVER_AUTH_URL = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${NAVER_CLIENT_ID}&state=${STATE_STRING}&redirect_uri=${NAVER_REDIRECT_URI}`;
+
+// 구글 로그인 구현 시 필요한 키값
+export const GOOGLE_CLIENT_ID =
+  "396499209310-e9dkj697kobuqsnhsicgjkoj2ogt6n63.apps.googleusercontent.com";
+
+export const GOOGLE_CLIENT_SECRET = "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";

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { GoogleOAuthProvider } from "@react-oauth/google";
 import "./index.css";
 import App from "./App";
 import { BrowserRouter } from "react-router-dom";
@@ -12,12 +13,14 @@ const { store } = configureStore();
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <>
-    <BrowserRouter>
-      <Provider store={store}>
-        <Spinner />
-        <ErrorComponent />
-        <App />
-      </Provider>
-    </BrowserRouter>
+    <GoogleOAuthProvider clientId="396499209310-e9dkj697kobuqsnhsicgjkoj2ogt6n63.apps.googleusercontent.com">
+      <BrowserRouter>
+        <Provider store={store}>
+          <Spinner />
+          <ErrorComponent />
+          <App />
+        </Provider>
+      </BrowserRouter>
+    </GoogleOAuthProvider>
   </>
 );

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Form, Formik, Field, ErrorMessage } from "formik";
+import { useGoogleLogin } from "@react-oauth/google";
+import axios from "axios";
 import * as Yup from "yup";
 import Button from "@component/Button";
 import * as actions from "@data/rootActions";
@@ -19,6 +21,21 @@ export default function Login() {
       .email("이메일 형태가 아닙니다.")
       .required("이메일을 입력하지 않았습니다."),
     password: Yup.string().required("패스워드를 입력하지 않았습니다."),
+  });
+
+  // 구글 로그인 구현하는 로직입니다. 테스트하실 때 사용해주세요. post url에 백엔드 쪽으로 요청 보내도록 url 세팅해주시면 됩니다.
+  // 구글 서버에 요청 보내는 건 라이브러리에서 해주고, 구글 서버와 통신 성공 했을 때 돌려받은 값을 code 에 담아서 백엔드에 보내는 형태입니다.
+  const googleLogin = useGoogleLogin({
+    onSuccess: async ({ code }) => {
+      console.log(`backend서버에 전달되는 값(credentials): ${code}`);
+      const tokens = await axios.post("여기에 백엔드 url 넣어주시면 됩니다", {
+        // http://localhost:3001/auth/google backend that will exchange the code
+        code,
+      });
+
+      console.log(tokens.data);
+    },
+    flow: "auth-code",
   });
 
   useEffect(() => {
@@ -85,10 +102,11 @@ export default function Login() {
             <div className="flex flex-col items-center justify-center p-6 border-t border-solid rounded-b border-slate-200">
               <Button
                 variant="contained"
-                text="로그인"
-                type="submit"
+                text="구글로 로그인"
+                type="button"
                 width="w-full"
                 backgroundColor="bg-themePink"
+                onClick={googleLogin}
               />
               <div className="flex justify-between w-full">
                 <a href={KAKAO_AUTH_URL}>


### PR DESCRIPTION
# 개요

- pages/Login.jsx 파일에 구글 로그인 관련 로직 설정하고, 구글로 로그인 버튼 클릭 시 필요한 로직 실행되도록 해두었습니다. 28번째 줄에 있는 `googleLogin` 함수에 백엔드 API 주소 넣어서 테스트하시면 됩니다.
- constants/index.js 파일에 로그인 구현에 필요한 키값들 작성해두었습니다. 테스트 하실 때 참고 부탁드립니다. (차후 삭제하면 되겠습니다.)