### PR TITLE
refactor: 로그인 및 닉네임 생성/수정 관련 로직 수정

### DIFF
--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -36,13 +36,17 @@ export default function Button(props) {
     ? "focus:outline-none focus:ring-1 focus:ring-offset-2"
     : "";
 
+  const buttonDisabledStyle = disabled ? "bg-opacity-[0.7]" : "";
+
+  const buttonCursorPointer = disabled ? "" : "cursor-pointer";
+
   return (
     <button
       disabled={disabled}
       type={type}
       form={form}
       value={value}
-      className={` cursor-pointer ${margin} ${borderRadius} ${width} ${height} ${color} ${buttonType} ${buttonFocus} ${backgroundColor} `}
+      className={`${buttonCursorPointer} ${margin} ${borderRadius} ${width} ${height} ${color} ${buttonType} ${buttonFocus} ${backgroundColor} ${buttonDisabledStyle}`}
       onClick={disabled ? null : onClick}
     >
       {text}

--- a/src/data/user/actions.js
+++ b/src/data/user/actions.js
@@ -73,7 +73,7 @@ export const createNickName =
           payload: response.data,
         });
 
-        localStorage.setItem("ls", response.data.token);
+        localStorage.setItem("Is", response.data.token);
         localStorage.setItem("nickname", response.data.nickname);
         navigate("/");
       } else {

--- a/src/pages/auth/Nickname.jsx
+++ b/src/pages/auth/Nickname.jsx
@@ -18,11 +18,13 @@ export default function NicknameModal() {
 
   const { accessToken, loginType, userSub, refreshToken } = userData;
 
-  const handleChangeInput = (e) => {
+  const handleNickNameInputChange = (e) => {
     setNickname(e.currentTarget.value);
   };
 
-  const handleClickButton = async () => {
+  const handleNickNameCreateRequest = async (e) => {
+    e.preventDefault();
+
     await dispatch(
       action.user.createNickName(
         {
@@ -39,12 +41,14 @@ export default function NicknameModal() {
 
   return (
     <div className="max-w-3xl mx-auto my-6 mt-28 w-96">
-      <div className="flex flex-col bg-white border-0 rounded-lg shadow-lg outline-none ">
+      <form
+        className="flex flex-col bg-white border-0 rounded-lg shadow-lg outline-none"
+        onSubmit={handleNickNameCreateRequest}
+      >
         <div className="flex flex-col items-center justify-center p-5 border-b border-solid rounded-t border-slate-200">
           <h3 className="text-3xl font-semibold text-black">JOIN</h3>
           <p>닉네임을 입력해 주세요</p>
         </div>
-
         <div className="flex flex-col items-center justify-center p-6 border-t border-solid rounded-b border-slate-200 ">
           <Input
             type="text"
@@ -55,10 +59,9 @@ export default function NicknameModal() {
             backgroundColor="bg-transparent"
             borderRadius="rounded-lg"
             border="border-solid border border-slate-400"
-            onChange={handleChangeInput}
+            onChange={handleNickNameInputChange}
           />
         </div>
-
         <div className="flex flex-col items-center justify-center px-6 py-2 border-t border-solid rounded-b border-slate-200 ">
           <Button
             variant="contained"
@@ -68,10 +71,9 @@ export default function NicknameModal() {
             width="w-full"
             backgroundColor="bg-themePink"
             borderRadius="rounded-lg"
-            onClick={handleClickButton}
-          ></Button>
+          />
         </div>
-      </div>
+      </form>
     </div>
   );
 }

--- a/src/pages/common/appbar/Appbar.jsx
+++ b/src/pages/common/appbar/Appbar.jsx
@@ -12,7 +12,7 @@ export default function Appbar(props) {
 
   const accessToken = localStorage.getItem("Is");
 
-  const handleOnJoinClick = () => {
+  const handleJoinClick = () => {
     navigate("/join");
   };
 
@@ -97,7 +97,7 @@ export default function Appbar(props) {
                 height="h-[35px]"
                 backgroundColor="bg-themePink"
                 borderRadius="rounded-2xl"
-                onClick={handleOnJoinClick}
+                onClick={handleJoinClick}
               ></Button>
             </>
           )}

--- a/src/pages/mypage/MyInfo/MyInfo.jsx
+++ b/src/pages/mypage/MyInfo/MyInfo.jsx
@@ -11,7 +11,6 @@ import Chart from "./chart";
 import PlayListCard from "@page/common/playListCard";
 import * as Mock from "@data/mock";
 import { BsPersonFill as PersonIcon } from "react-icons/bs";
-import * as apis from "@service/apis/movieMang";
 
 export default function MyPage() {
   const userData = useSelector(selector.user.getUserData);
@@ -19,34 +18,40 @@ export default function MyPage() {
 
   const dispatch = useDispatch();
 
+  const currentUserNickName = localStorage.getItem("nickname");
+
+  console.log(currentUserNickName);
+
   function loginType() {
     let sns = userData.loginType;
+    console.log(sns);
     if (sns === "kakao") {
       return (
-        <div className="w-[94px] py-2 px-3 mt-2 rounded bg-[#FEE500]">
+        <div className="w-[94px] py-2 px-3 mt-2 rounded bg-[#FEE500] whitespace-pre">
           Kakao 계정
         </div>
       );
     } else if (sns === "naver") {
       return (
-        <div className="w-[91px] py-2 px-3 mt-2 rounded text-white bg-[#18CE5F]">
+        <div className="w-[91px] py-2 px-3 mt-2 rounded text-white bg-[#18CE5F] whitespace-pre">
           Naver 계정
         </div>
       );
     } else {
       return (
-        <div className="w-[98px] py-2 px-3 mt-2 rounded text-white bg-[#4285F4]">
+        <div className="w-[98px] py-2 px-3 mt-2 rounded text-white bg-[#4285F4] whitespace-pre">
           Google 계정
         </div>
       );
     }
   }
 
-  function handleChange(e) {
+  function handleNickNameInputChange(e) {
     setNickName(e.currentTarget.value);
   }
 
-  const handleButtonClick = async () => {
+  const handleNickNameChangeRequest = async (e) => {
+    e.preventDefault();
     await dispatch(
       action.user.editNickName({
         nickname,
@@ -59,12 +64,12 @@ export default function MyPage() {
       <div className="w-[20%]">
         <SNB />
       </div>
-      <div className=" p-10 max-w-2xl w-full">
+      <div className="w-full max-w-2xl p-10 ">
         <div className="flex">
-          <div className="w-52 h-52 bg-gray-400 rounded">
+          <div className="bg-gray-400 rounded w-52 h-52">
             <PersonIcon className="w-52 h-52" fill="#d1d5db" />
           </div>
-          <div className="mx-5 my-2">
+          <form className="mx-5 my-2" onSubmit={handleNickNameChangeRequest}>
             <Input
               type="text"
               value={nickname}
@@ -76,32 +81,31 @@ export default function MyPage() {
               border="border-solid border border-slate-400"
               textColor="text-textMainColor"
               backgroundColor="bg-searchBarBackgroundColor"
-              onChange={handleChange}
+              onChange={handleNickNameInputChange}
             />
             <Button
               text="수정"
-              type="button"
+              type="submit"
               color="text-white"
               width="w-[80px]"
               height="h-[38px]"
               backgroundColor="bg-themePink"
               borderRadius="rounded"
-              onClick={handleButtonClick}
-            ></Button>
+            />
             {loginType()}
-          </div>
+          </form>
         </div>
         <div className="my-10">
           <Chart />
         </div>
         <div>
-          <h1 className="text-xl font-bold  text-textMainColor">
+          <h1 className="text-xl font-bold text-textMainColor">
             나의 플레이리스트
           </h1>
           <div className="float-right mb-4 text-xs text-textMainColor">
             <NavLink to={"playlist"}>전체보기</NavLink>
           </div>
-          <div className="flex w-full justify-between items-center">
+          <div className="flex items-center justify-between w-full">
             {Mock.playList.playList.slice(0, 2).map((movie, index) => {
               return (
                 <div key={index}>

--- a/src/pages/mypage/MyInfo/MyInfo.jsx
+++ b/src/pages/mypage/MyInfo/MyInfo.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState, useEffect } from "react";
 import { NavLink } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
 import * as selector from "@data/rootSelectors";
@@ -14,15 +14,15 @@ import { BsPersonFill as PersonIcon } from "react-icons/bs";
 
 export default function MyPage() {
   const userData = useSelector(selector.user.getUserData);
+
   const [nickname, setNickName] = useState(userData.nickname);
+  const [isNickNameSame, setIsNickNameSame] = useState(false);
 
   const dispatch = useDispatch();
 
   const currentUserNickName = localStorage.getItem("nickname");
 
-  console.log(currentUserNickName);
-
-  function loginType() {
+  const loginType = () => {
     let sns = userData.loginType;
     console.log(sns);
     if (sns === "kakao") {
@@ -44,20 +44,29 @@ export default function MyPage() {
         </div>
       );
     }
-  }
+  };
 
-  function handleNickNameInputChange(e) {
+  const handleNickNameInputChange = (e) => {
     setNickName(e.currentTarget.value);
-  }
+  };
 
   const handleNickNameChangeRequest = async (e) => {
     e.preventDefault();
+
     await dispatch(
       action.user.editNickName({
         nickname,
       })
     );
   };
+
+  useEffect(() => {
+    if (nickname === currentUserNickName) {
+      setIsNickNameSame(true);
+    } else {
+      setIsNickNameSame(false);
+    }
+  }, [currentUserNickName, nickname]);
 
   return (
     <div className="flex w-[1170px] mx-auto">
@@ -91,6 +100,7 @@ export default function MyPage() {
               height="h-[38px]"
               backgroundColor="bg-themePink"
               borderRadius="rounded"
+              disabled={isNickNameSame}
             />
             {loginType()}
           </form>


### PR DESCRIPTION
# 개요

- 오타로 인해 닉네임 생성 후 AppBar에 로그인 된 UI가 표시되지 않던 문제 수정
- 마이페이지에서 sns 계정 표시 부분 텍스트 줄바꿈 되지 않도록 수정
- 마이페이지에서 닉네임 수정 Input에 입력된 텍스트가 현재 닉네임과 일치할 경우 button disabled 되도록 변경
- button 컴포넌트 disabled 된 상태일 때 opacity 값 다르게 해서 UI 다르게 보이도록 수정 / cursor-pointer 되지 않도록 변경
- 닉네임 최초 생성 / 닉네임 변경 시에 input에 입력 후 클릭하거나 enter 키를 입력했을 때도 request가 가도록 form 태그 안에 input/button 태그 넣는 형태로 변경
- 함수 선언 방식 화살표 함수 형태로 통일 및 함수 이름에 함수 역할이 더 드러나도록 수정